### PR TITLE
Removed `django.core.context_processors.request`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,35 @@ with the pypugjs compiler.
 Django
 ------
 
+**For Django 1.10+**
+
+In `settings.py`, add a `loader` to `TEMPLATES` like so:
+
+```python
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+            'loaders': [
+                # PyPugJS part:   ##############################
+                ('pypugjs.ext.django.Loader', (
+                    'django.template.loaders.filesystem.Loader',
+                    'django.template.loaders.app_directories.Loader',
+                ))
+            ],
+            'builtins': ['pypugjs.ext.django.templatetags'],
+        },
+    },
+]
+```
+
 **For Django 1.9**
 
 In `settings.py`, add a `loader` to `TEMPLATES` like so:


### PR DESCRIPTION
In Django 1.10+ `django.core.context_processors.request` throws an error. Removing it fixes it.